### PR TITLE
Keep unix file permissions when unzipping

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,8 @@ os:
   - osx
   - linux
 
-before_install:
-  - if [ $TRAVIS_OS_NAME == "linux" ]; then
-      export CXX="g++-4.9" CC="gcc-4.9" DISPLAY=:99.0;
-      sh -e /etc/init.d/xvfb start;
-      sleep 3;
-    fi
+services:
+  - xvfb 
 
 install:
   - npm install

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -134,7 +134,7 @@ function extract(content:Buffer, path:string) {
                         if (err) {
                             throw err;
                         }
-                        stream!.pipe(fs.createWriteStream(mappedPath));
+                        stream!.pipe(fs.createWriteStream(mappedPath, {mode: entry.externalFileAttributes >>> 16}));
                     });
                 }
             }


### PR DESCRIPTION
When generating a Spring Boot project, the maven wrapper files do not have execute permissions.
![image](https://user-images.githubusercontent.com/20326645/63807570-fb453f80-c8eb-11e9-9311-65c581d2448a.png)

With this PR, the maven wrapper files retain their execute permissions:
![image](https://user-images.githubusercontent.com/20326645/63807639-216adf80-c8ec-11e9-8871-73adabdf5e65.png)

This is because the permissions were not preserved when unzipping.
This PR works under the assumption that the zip file entries contain permissions in the left-most 16 bits of `entry.externalFileAttributes`. If this is a bad assumption, please let me know. 

[This](https://github.com/thejoshwolfe/yauzl/issues/101#issuecomment-448073570) conversation in the yauzl repository was used as a reference.

Signed-off-by: David Kwon <dakwon@redhat.com>