### PR TITLE
Add preview tag to true

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "license": "EPL-2.0",
     "publisher": "redhat",
     "author": "Red Hat",
+    "preview": true,
     "icon": "icons/Project_Initializer.png",
     "homepage": "https://github.com/fabric8-launcher/launcher-vscode-extension/blob/master/README.md",
     "repository": {


### PR DESCRIPTION
This change is necessary as all the extensions in VSCode Marketplace supported by Red Hat should be in `Preview` state.