### PR TITLE
FUSETOOLS2-431 and FUSETOOLS2-436

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
 sudo: false
+language: node_js
+
+node_js:
+  - node
 
 os:
   - osx

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
         "tslint": "^5.17.0",
         "typescript": "^3.5.2",
         "vscode-test": "^1.2.3",
-        "vscode-extension-tester": "^2.3.0"
+        "vscode-extension-tester": "^3.0.1"
     },
     "dependencies": {
         "@types/request": "^2.47.0",

--- a/src/ui-test/baseExtensionTest.ts
+++ b/src/ui-test/baseExtensionTest.ts
@@ -1,4 +1,4 @@
-import { ExtensionsViewSection, ActivityBar, ExtensionsViewItem, QuickOpenBox } from 'vscode-extension-tester';
+import { ExtensionsViewSection, ActivityBar, ExtensionsViewItem, InputBox, QuickOpenBox } from 'vscode-extension-tester';
 import { ProjectInitializer } from './common/projectInitializerConstants';
 import { openCommandPrompt } from './common/commonUtils';
 import { expect } from 'chai';
@@ -6,7 +6,7 @@ import { expect } from 'chai';
 export function baseExtensionUITest() {
     describe('Verify extension\'s base assets available after install', () => {
 
-        let inputBox: QuickOpenBox;
+        let inputBox: InputBox | QuickOpenBox;
 
         it('Command Palette prompt knows project initializer commands', async function () {
             this.timeout(4000);

--- a/src/ui-test/camelProjectCreateTest.ts
+++ b/src/ui-test/camelProjectCreateTest.ts
@@ -1,5 +1,5 @@
-import { openCommandPrompt, removeFilePathRecursively, getIndexOfQuickPickItem, notificationExists } from "./common/commonUtils";
 import { InputBox, QuickOpenBox, ActivityBar, Notification, TreeItem, WebDriver, VSBrowser } from "vscode-extension-tester";
+import { openCommandPrompt, removeFilePathRecursively, getIndexOfQuickPickItem, notificationExists, typeCommandConfirm } from "./common/commonUtils";
 import * as fs from "fs";
 import { ProjectInitializer } from "./common/projectInitializerConstants";
 import { expect } from "chai";
@@ -43,9 +43,8 @@ export function testCreatingCamelProject() {
         CAMEL_MISSIONS_EXPECTED.forEach( async function(mission) {
             it('Test creating Camel/Fuse project: ' + mission + ", runtime & version: " + RUNTIME_VERSION, async function () {
                 this.timeout(20000); 
-                const commandPrompt = await openCommandPrompt();
-                await commandPrompt.setText('>Project: ');
-                await commandPrompt.selectQuickPick(ProjectInitializer.PI_GENERAL.camel);
+                await openCommandPrompt();
+                await typeCommandConfirm(`>${ProjectInitializer.PI_GENERAL.camel}`, true);
                 inputBox = await InputBox.create();
                 await inputBox.selectQuickPick(mission);
                 inputBox = await InputBox.create();

--- a/src/ui-test/camelProjectCreateTest.ts
+++ b/src/ui-test/camelProjectCreateTest.ts
@@ -1,5 +1,5 @@
-import { InputBox, QuickOpenBox, ActivityBar, Notification, By, TreeItem, WebDriver, VSBrowser } from "vscode-extension-tester";
 import { openCommandPrompt, removeFilePathRecursively, getIndexOfQuickPickItem, notificationExists } from "./common/commonUtils";
+import { InputBox, QuickOpenBox, ActivityBar, Notification, TreeItem, WebDriver, VSBrowser } from "vscode-extension-tester";
 import * as fs from "fs";
 import { ProjectInitializer } from "./common/projectInitializerConstants";
 import { expect } from "chai";
@@ -21,7 +21,7 @@ export function testCreatingCamelProject() {
     describe('Verify Project initializer Camel/Fuse projects creation', async function() {
 
         let homedir: string;
-        let inputBox: QuickOpenBox;
+        let inputBox: InputBox | QuickOpenBox;
         let driver: WebDriver;
 
         before(async function() {
@@ -32,7 +32,7 @@ export function testCreatingCamelProject() {
                 fs.mkdirSync(homedir);
             }
             await openCommandPrompt();
-            const quick = await QuickOpenBox.create();
+            const quick = await InputBox.create();
             await quick.setText(">Extest: Add Folder");
             await quick.confirm();
             let confirmedPrompt = await InputBox.create();
@@ -68,14 +68,15 @@ export function testCreatingCamelProject() {
                 // check the notification "Project saved to ;
                 // on Windows seems the C: is translated to c: by VSCode so we can't check this part
                 const notification = await driver.wait(() => { return notificationExists('Project saved to '); }, 5000) as Notification;
-                await driver.actions().mouseMove(notification).perform();
-                await notification.findElement(By.className("codicon-close")).click();
+                await notification.dismiss();
                 // check explorer that it contains created project
                 const explorerView = await new ActivityBar().getViewControl("Explorer").openView();
                 const viewTab = await explorerView.getContent().getSection("Untitled (Workspace)");
-                let tree = await viewTab.getVisibleItems() as TreeItem[];
-                let items = tree.map( (item: TreeItem) => item.getLabel());
-                expect(items).to.contains.members(["pom.xml"]);
+                
+                await driver.wait(async () => {
+                    const items = await viewTab.getVisibleItems() as TreeItem[];
+                    return items.find(item => item.getLabel() === "pom.xml") !== undefined;
+                }, 8000, "Could not find pom.xml in file explorer.").catch(expect.fail);
             });
         });
 

--- a/src/ui-test/camelProjectOfferingTest.ts
+++ b/src/ui-test/camelProjectOfferingTest.ts
@@ -15,7 +15,7 @@ const CAMEL_MISSIONS_EXPECTED = [
 export function testFuseProjectOffering() {
     describe('Verify Project initializer Camel/Fuse Command palette options', async function() {
 
-        let inputBox: QuickOpenBox;
+        let inputBox: InputBox | QuickOpenBox;
         let catalogFuse: any;
 
         before(async function() {

--- a/src/ui-test/commandPaletteOptionsTest.ts
+++ b/src/ui-test/commandPaletteOptionsTest.ts
@@ -16,7 +16,7 @@ const GENERAL_PROJECT_EXPECTED = [
 export function testCommandPaletteOffering() {
     describe('Verify Project initializer Command palette options', () => {
 
-        let inputBox: QuickOpenBox;
+        let inputBox: InputBox | QuickOpenBox;
 
         it('Command palette should show proper options on the first level', async function () {
             this.timeout(5000);

--- a/src/ui-test/commandPaletteOptionsTest.ts
+++ b/src/ui-test/commandPaletteOptionsTest.ts
@@ -1,8 +1,7 @@
-import { QuickPickItem, QuickOpenBox, InputBox } from "vscode-extension-tester";
-import { getCommandPromptOptions, openCommandPrompt, typeCommandConfirm, convertArrayObjectsToText } from "./common/commonUtils";
+import { InputBox, QuickOpenBox } from "vscode-extension-tester";
+import { getCommandPromptOptions, openCommandPrompt, typeCommandConfirm, verifyQuickPicks } from "./common/commonUtils";
 import { ProjectInitializer } from "./common/projectInitializerConstants";
 import { assertEqualOptions } from "./common/testUtils";
-
 
 
 const GENERAL_PROJECT_EXPECTED = [
@@ -28,10 +27,8 @@ export function testCommandPaletteOffering() {
         it('Options available after general Project Initializer project generation', async function () {
             this.timeout(10000);
             inputBox = await openCommandPrompt();
-            await typeCommandConfirm('>' + ProjectInitializer.PI_GENERAL.general);
-            const confirmedPrompt = await InputBox.create();
-            const options = await convertArrayObjectsToText<QuickPickItem>(await confirmedPrompt.getQuickPicks());
-            assertEqualOptions(GENERAL_PROJECT_EXPECTED, options);
+            await typeCommandConfirm('>' + ProjectInitializer.PI_GENERAL.general, true);
+            await verifyQuickPicks(inputBox, GENERAL_PROJECT_EXPECTED);
         });
 
         after(async function () {

--- a/src/ui-test/common/commonUtils.ts
+++ b/src/ui-test/common/commonUtils.ts
@@ -1,5 +1,6 @@
-import { Workbench, QuickPickItem, QuickOpenBox, Notification, InputBox } from "vscode-extension-tester";
+import { Workbench, QuickPickItem, InputBox, Notification } from "vscode-extension-tester";
 import * as fs from "fs";
+
 let path = require('path');
 /**
  * @author Ondrej Dockal <odockal@redhat.com>
@@ -8,7 +9,7 @@ async function openCommandPrompt() {
     return new Workbench().openCommandPrompt();
 }
 
-async function runCommands(...commands: string []) {
+async function runCommands(...commands: string[]) {
     const commandPrompt = await openCommandPrompt();
     for (let index = 0; index < commands.length; index++) {
         const command = commands[index];
@@ -19,17 +20,17 @@ async function runCommands(...commands: string []) {
 }
 
 async function typeCommandConfirm(command: string) {
-    const prompt = await QuickOpenBox.create();
+    const prompt = await InputBox.create();
     await prompt.setText(command);
     await prompt.confirm();
 }
 
- async function getCommandPromptOptions(command: string) {
-    const commandPrompt = await QuickOpenBox.create();
+async function getCommandPromptOptions(command: string) {
+    const commandPrompt = await InputBox.create();
     await commandPrompt.setText(command);
     const options = await commandPrompt.getQuickPicks();
     return convertArrayObjectsToText<QuickPickItem>(options);
- }
+}
 
 async function convertArrayObjectsToText<T extends QuickPickItem>(array: T[]) {
     let options = [];
@@ -78,7 +79,7 @@ async function removeFolderFromWorkspace(dir: string) {
     await typeCommandConfirm(">Workspaces: Remove Folder from workspace");
     const input = await InputBox.create();
     let dirs = await convertArrayObjectsToText(await input.getQuickPicks());
-    if (dirs.filter( item => { return item.indexOf(dir) === 0;}).length === 0) {
+    if (dirs.filter(item => { return item.indexOf(dir) === 0; }).length === 0) {
         throw Error("Folder " + dir + " is not set as workspace, cannot be removed, available folders: " + dirs);
     }
     await input.selectQuickPick(dir);
@@ -86,7 +87,7 @@ async function removeFolderFromWorkspace(dir: string) {
 
 async function addFolderToWorkspace(dir: string) {
     await openCommandPrompt();
-    const quick = await QuickOpenBox.create();
+    const quick = await InputBox.create();
     await quick.setText(">Extest: Add Folder");
     await quick.confirm();
     let confirmedPrompt = await InputBox.create();
@@ -107,13 +108,13 @@ function removeFilePathRecursively(filepath: string, includeRootDir: boolean = f
     }
 }
 
-export { 
-    convertArrayObjectsToText, 
+export {
+    convertArrayObjectsToText,
     typeCommandConfirm,
     getCommandPromptOptions,
     openCommandPrompt,
-    runCommands, 
-    notificationExists, 
+    runCommands,
+    notificationExists,
     convertArrayObjectsToTextAndDescription,
     getIndexOfQuickPickItem,
     addFolderToWorkspace,


### PR DESCRIPTION
### FUSETOOLS2-431
* replace deprecated QuickInputBox
* modify travis configuration so transitive dependency of vscode-extension-tester can be imported.
* add wait condition for pom.xml lookup

### FUSETOOLS2-436
* execute commands via quick picks instead of typing in command and confirming first quick pick.