### PR TITLE
FUSETOOLS2-435 - Make ui test cases atomic

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
         "tslint": "^5.17.0",
         "typescript": "^3.5.2",
         "vscode-test": "^1.2.3",
-        "vscode-extension-tester": "^3.0.1"
+        "vscode-extension-tester": "^3.0.2"
     },
     "dependencies": {
         "@types/request": "^2.47.0",

--- a/src/ui-test/allTestsSuite.ts
+++ b/src/ui-test/allTestsSuite.ts
@@ -1,12 +1,17 @@
-import { baseExtensionUITest } from "./baseExtensionTest";
-import { testCommandPaletteOffering } from "./commandPaletteOptionsTest";
-import { testCreatingCamelProject } from "./camelProjectCreateTest";
-import { testFuseProjectOffering } from "./camelProjectOfferingTest";
+import { baseExtensionUITest } from './baseExtensionTest';
+import { QuickPickItem } from 'vscode-extension-tester';
+import { testCommandPaletteOffering } from './commandPaletteOptionsTest';
+import { testCreatingCamelProject } from './camelProjectCreateTest';
+import { testFuseProjectOffering } from './camelProjectOfferingTest';
 
 /**
  * @author Ondrej Dockal <odockal@redhat.com>
  */
-describe("Project initializer UI tests", () => {
+describe('Project initializer UI tests', function () {
+   QuickPickItem.prototype.select = async function () {
+      await this.getDriver().executeScript('arguments[0].click();', this);
+   };
+
    baseExtensionUITest();
    testCommandPaletteOffering();
    testCreatingCamelProject();

--- a/src/ui-test/baseExtensionTest.ts
+++ b/src/ui-test/baseExtensionTest.ts
@@ -1,7 +1,13 @@
-import { ExtensionsViewSection, ActivityBar, ExtensionsViewItem, InputBox, QuickOpenBox } from 'vscode-extension-tester';
-import { ProjectInitializer } from './common/projectInitializerConstants';
-import { openCommandPrompt } from './common/commonUtils';
+import {
+    ActivityBar,
+    ExtensionsViewItem,
+    ExtensionsViewSection,
+    InputBox,
+    QuickOpenBox
+} from 'vscode-extension-tester';
 import { expect } from 'chai';
+import { openCommandPrompt } from './common/commonUtils';
+import { ProjectInitializer } from './common/projectInitializerConstants';
 
 export function baseExtensionUITest() {
     describe('Verify extension\'s base assets available after install', () => {
@@ -10,7 +16,7 @@ export function baseExtensionUITest() {
 
         it('Command Palette prompt knows project initializer commands', async function () {
             this.timeout(4000);
-            inputBox = await openCommandPrompt();
+            inputBox = await openCommandPrompt(this.timeout() - 500);
             await verifyCommandPalette(inputBox);
         });
 
@@ -34,7 +40,7 @@ export function baseExtensionUITest() {
 }
 
 async function verifyCommandPalette(input: any) {
-    await input.setText(ProjectInitializer.PROJECT_INITIALIZER_NAME);
+    await input.setText(`>${ProjectInitializer.PROJECT_INITIALIZER_NAME}`);
     const options = await input.getQuickPicks();
     expect(options[0].getText()).not.equal('No commands matching');
 }

--- a/src/ui-test/camelProjectCreateTest.ts
+++ b/src/ui-test/camelProjectCreateTest.ts
@@ -1,8 +1,22 @@
-import { InputBox, QuickOpenBox, ActivityBar, Notification, TreeItem, WebDriver, VSBrowser } from "vscode-extension-tester";
-import { openCommandPrompt, removeFilePathRecursively, getIndexOfQuickPickItem, notificationExists, typeCommandConfirm } from "./common/commonUtils";
-import * as fs from "fs";
-import { ProjectInitializer } from "./common/projectInitializerConstants";
-import { expect } from "chai";
+import * as fs from 'fs';
+import {
+    ActivityBar,
+    InputBox,
+    QuickOpenBox,
+    QuickPickItem,
+    TreeItem,
+    VSBrowser,
+    WebDriver
+} from 'vscode-extension-tester';
+import { expect } from 'chai';
+import {
+    notificationExists,
+    openCommandPrompt,
+    removeFilePathRecursively,
+    typeCommandConfirm,
+    waitForQuickPick
+} from './common/commonUtils';
+import { ProjectInitializer } from './common/projectInitializerConstants';
 let os = require('os');
 let path = require('path');
 
@@ -10,88 +24,125 @@ const CAMEL_MISSIONS_EXPECTED = [
     'circuit-breaker', 'configmap', 'health-check', 'rest-http', 'istio-distributed-tracing'
 ];
 
-const DIR = "Fuse_Camel_TestFolder";
-const RUNTIME_VERSION = "fuse redhat750";
+const DIR = 'Fuse_Camel_TestFolder';
+const RUNTIME_VERSION = 'fuse redhat750';
 
 /**
  * @author Ondrej Dockal <odockal@redhat.com>
  */
 export function testCreatingCamelProject() {
 
-    describe('Verify Project initializer Camel/Fuse projects creation', async function() {
+    describe('Verify Project initializer Camel/Fuse projects creation', async function () {
 
         let homedir: string;
         let inputBox: InputBox | QuickOpenBox;
         let driver: WebDriver;
 
-        before(async function() {
+        before(async function () {
             this.timeout(10000);
             homedir = os.homedir() + path.sep + DIR;
             driver = VSBrowser.instance.driver;
-            if (! fs.existsSync(homedir)) {
+            if (!fs.existsSync(homedir)) {
                 fs.mkdirSync(homedir);
             }
             await openCommandPrompt();
             const quick = await InputBox.create();
-            await quick.setText(">Extest: Add Folder");
+            await quick.setText('>Extest: Add Folder');
             await quick.confirm();
             let confirmedPrompt = await InputBox.create();
             await confirmedPrompt.setText(homedir);
             await confirmedPrompt.confirm();
         });
 
-        CAMEL_MISSIONS_EXPECTED.forEach( async function(mission) {
-            it('Test creating Camel/Fuse project: ' + mission + ", runtime & version: " + RUNTIME_VERSION, async function () {
-                this.timeout(20000); 
-                await openCommandPrompt();
-                await typeCommandConfirm(`>${ProjectInitializer.PI_GENERAL.camel}`, true);
-                inputBox = await InputBox.create();
-                await inputBox.selectQuickPick(mission);
-                inputBox = await InputBox.create();
-                let index = await getIndexOfQuickPickItem(RUNTIME_VERSION, await inputBox.getQuickPicks());
-                await inputBox.selectQuickPick(index);
-                // settings default groupID
-                inputBox = await InputBox.create();
-                await inputBox.confirm();
-                // setting default artifactID
-                inputBox = await InputBox.create();
-                await inputBox.confirm();
-                // setting default version
-                inputBox = await InputBox.create();
-                await inputBox.confirm();
-                console.log("vrsion confirmed");
-                // select home dir
-                inputBox = await InputBox.create();
-                await inputBox.selectQuickPick(DIR);
+        for (const mission of CAMEL_MISSIONS_EXPECTED) {
+            describe('Test creating Camel/Fuse project: ' + mission + ', runtime & version: ' + RUNTIME_VERSION, async function () {
+                this.timeout(7000);
 
-                // check the notification "Project saved to ;
-                // on Windows seems the C: is translated to c: by VSCode so we can't check this part
-                const notification = await driver.wait(() => { return notificationExists('Project saved to '); }, 5000) as Notification;
-                await notification.dismiss();
-                // check explorer that it contains created project
-                const explorerView = await new ActivityBar().getViewControl("Explorer").openView();
-                const viewTab = await explorerView.getContent().getSection("Untitled (Workspace)");
-                
-                await driver.wait(async () => {
-                    const items = await viewTab.getVisibleItems() as TreeItem[];
-                    return items.find(item => item.getLabel() === "pom.xml") !== undefined;
-                }, 8000, "Could not find pom.xml in file explorer.").catch(expect.fail);
+                before('Open command prompt', async function () {
+                    inputBox = await openCommandPrompt().catch(() => expect.fail('Could not open command palette - timed out'));
+                });
+
+                after(async function () {
+                    this.timeout(10000);
+                    if (inputBox && await inputBox.isDisplayed()) {
+                        await inputBox.cancel();
+                    }
+                    // delete created project - files from the folder
+                    removeFilePathRecursively(homedir);
+                    await new ActivityBar().getViewControl('Explorer').closeView();
+                });
+
+                it('Select camel project', async function () {
+                    await typeCommandConfirm(`>${ProjectInitializer.PI_GENERAL.camel}`, QuickPickItem.prototype.getLabel);
+                });
+
+                it(`Select mission: ${mission}`, async function () {
+                    inputBox = await InputBox.create();
+                    expect(await inputBox.getPlaceHolder()).to.be.equal('Choose mission');
+                    const quickPick = await waitForQuickPick({
+                        input: inputBox,
+                        quickPickText: mission,
+                        quickPickGetter: QuickPickItem.prototype.getLabel,
+                        timeout: 5000
+                    }).catch(() => expect.fail(`Could not find mission: ${mission}`));
+                    await quickPick.select();
+                });
+
+                it(`Select runtime version: ${RUNTIME_VERSION}`, async function () {
+                    inputBox = await InputBox.create();
+                    expect(await inputBox.getPlaceHolder()).to.be.equal('Choose runtime');
+                    const quickPick = await waitForQuickPick({
+                        input: inputBox,
+                        quickPickText: RUNTIME_VERSION,
+                        quickPickGetter: async function (this: QuickPickItem) { return `${await this.getLabel()} ${await this.getDescription()}`; },
+                        timeout: 5000
+                    }).catch(async (e) => expect.fail(`Could not find runtime version(${RUNTIME_VERSION}) for ${mission}. Error: ${e}`));
+                    await quickPick.select();
+                });
+
+                it('Select default groupId', async function () {
+                    inputBox = await InputBox.create();
+                    expect(await inputBox.getPlaceHolder()).to.be.equal('Enter the group id');
+                    await inputBox.confirm();
+                });
+
+                it('Select default artifactId', async function () {
+                    inputBox = await InputBox.create();
+                    expect(await inputBox.getPlaceHolder()).to.be.equal('Enter the artifact id');
+                    await inputBox.confirm();
+                });
+
+                it('Select default version', async function () {
+                    inputBox = await InputBox.create();
+                    expect(await inputBox.getPlaceHolder()).to.be.equal('Enter the version');
+                    await inputBox.confirm();
+                });
+
+
+                it('Select home directory', async function () {
+                    inputBox = await InputBox.create();
+                    expect(await inputBox.getPlaceHolder()).to.be.equal('Select the target workspace folder');
+                    await inputBox.selectQuickPick(DIR);
+                });
+
+                it('Check notification', async function () {
+                    this.timeout(12000);
+                    // check the notification 'Project saved to ;
+                    // on Windows seems the C: is translated to c: by VSCode so we can't check this part
+                    const notification = await notificationExists('Project saved to ', 5000).catch((e) => expect.fail(`Could not find notification: ${e}`));
+                    await notification.dismiss().catch((e) => `Could not dismiss notifications. Error: ${e}`);
+                });
+
+                it('Check if explorer contains created project', async function () {
+                    // check explorer that it contains created project
+                    const explorerView = await new ActivityBar().getViewControl('Explorer').openView();
+                    const viewTab = await explorerView.getContent().getSection('Untitled (Workspace)');
+                    await driver.wait(async () => {
+                        const items = await viewTab.getVisibleItems() as TreeItem[];
+                        return items.find(item => item.getLabel() === 'pom.xml') !== undefined;
+                    }, 8000, 'Could not find pom.xml in file explorer.').catch(expect.fail);
+                });
             });
-        });
-
-        afterEach(async function () {
-            this.timeout(5000);
-            // delete created project - files from the folder
-            removeFilePathRecursively(homedir);
-            await new ActivityBar().getViewControl('Explorer').closeView();
-        });
-
-        after(async function () {
-            this.timeout(10000);
-            if (inputBox && await inputBox.isDisplayed()) {
-                await inputBox.cancel();
-            }
-        });
-
+        }
     });
 }

--- a/src/ui-test/camelProjectOfferingTest.ts
+++ b/src/ui-test/camelProjectOfferingTest.ts
@@ -1,9 +1,15 @@
-import { QuickOpenBox, InputBox, QuickPickItem } from "vscode-extension-tester";
-import { openCommandPrompt, typeCommandConfirm, convertArrayObjectsToText, convertArrayObjectsToTextAndDescription } from "./common/commonUtils";
-import { assertEqualOptions } from "./common/testUtils";
-import { ProjectInitializer } from "./common/projectInitializerConstants";
-import { Catalog } from "../Catalog";
-import { expect } from "chai";
+import { assertEqualOptions } from './common/testUtils';
+import { Catalog } from '../Catalog';
+import {
+    convertArrayObjectsToText,
+    convertArrayObjectsToTextAndDescription,
+    openCommandPrompt,
+    typeCommandConfirm
+} from './common/commonUtils';
+import { expect } from 'chai';
+import { InputBox, QuickOpenBox, QuickPickItem } from 'vscode-extension-tester';
+import { it } from 'mocha';
+import { ProjectInitializer } from './common/projectInitializerConstants';
 
 const CAMEL_MISSIONS_EXPECTED = [
     'circuit-breaker', 'configmap', 'health-check', 'rest-http', 'istio-distributed-tracing'
@@ -13,63 +19,71 @@ const CAMEL_MISSIONS_EXPECTED = [
  * @author odockal@redhat.com
  */
 export function testFuseProjectOffering() {
-    describe('Verify Project initializer Camel/Fuse Command palette options', async function() {
+    describe('Verify Project initializer Camel/Fuse Command palette options', async function () {
 
         let inputBox: InputBox | QuickOpenBox;
-        let catalogFuse: any;
+        let catalogBuilder = new Catalog(ProjectInitializer.BUILDER_CATALOG_URL);
+        let catalog = await catalogBuilder.getCatalog();
+        let catalogFuse = filterCatalogForRuntimes(catalog, ProjectInitializer.CAMEL_FUSE_RUNTIME_IDS);
 
-        before(async function() {
-            this.timeout(5000);
-            let catalogBuilder = new Catalog(ProjectInitializer.BUILDER_CATALOG_URL);
-            let catalog = await catalogBuilder.getCatalog();
-            catalogFuse = filterCatalogForRuntimes(catalog, ProjectInitializer.CAMEL_FUSE_RUNTIME_IDS);
-        });
+        for (let mission of catalogFuse.missions) {
+            describe(`Verifying runtimes and versions for '${mission.id}' mission`, async function () {
+                this.timeout(6000);
 
-        it('Available missions and runtime versions correspond to Camel/Fuse project catalog', async function () {
-            this.timeout(30000);
-            for (let mission of catalogFuse.missions) {
-                console.log("\tVerifying runtimes and versions for " + mission.id + " mission");
-                await openCommandPrompt();
-                await typeCommandConfirm('>' + ProjectInitializer.PI_GENERAL.camel);
-                inputBox = await InputBox.create();
-                await inputBox.selectQuickPick(mission.id);
-                let expectedRefs = findRefsForMissions(mission.id, catalogFuse.boosters);
-                let expected = expectedRefs.map( (runver: any) => runver.runtime + " " + runver.version);
-                inputBox = await InputBox.create();
-                let actual = await convertArrayObjectsToTextAndDescription<QuickPickItem>(await inputBox.getQuickPicks());
-                expect(expected).to.have.same.members(actual);
-                await inputBox.cancel();
-            }
-        });
+                before(async function () {
+                    inputBox = await openCommandPrompt();
+                });
+
+                after(async function () {
+                    if (inputBox && await inputBox.isDisplayed()) {
+                        await inputBox.cancel();
+                    }
+                });
+
+                it(`Execute command ${ProjectInitializer.PI_GENERAL.camel}`, async function () {
+                    await typeCommandConfirm('>' + ProjectInitializer.PI_GENERAL.camel, QuickPickItem.prototype.getLabel);
+                });
+
+                it(`Select mission: ${mission.id}`, async function () {
+                    inputBox = await InputBox.create();
+                    expect(await inputBox.getPlaceHolder()).to.be.equal('Choose mission');
+                    await inputBox.selectQuickPick(mission.id);
+                });
+
+                it('Verify mission versions', async function () {
+
+                    let expectedRefs = findRefsForMissions(mission.id, catalogFuse.boosters);
+                    let expected = expectedRefs.map((runver: any) => runver.runtime + ' ' + runver.version);
+                    inputBox = await InputBox.create();
+                    let actual = await convertArrayObjectsToTextAndDescription<QuickPickItem>(await inputBox.getQuickPicks());
+                    expect(expected).to.have.same.members(actual);
+                });
+            });
+        }
 
         it('Verify options available for Camel/Fuse project', async function () {
             this.timeout(10000);
-                await openCommandPrompt();
-                await typeCommandConfirm('>' + ProjectInitializer.PI_GENERAL.camel);
-                inputBox = await InputBox.create();
-                assertEqualOptions(CAMEL_MISSIONS_EXPECTED, await convertArrayObjectsToText<QuickPickItem>(await inputBox.getQuickPicks()));
-        });
-
-        after(async function () {
-            if (inputBox && await inputBox.isDisplayed()) {
-                await inputBox.cancel();
-            }
+            await openCommandPrompt();
+            await typeCommandConfirm('>' + ProjectInitializer.PI_GENERAL.camel, QuickPickItem.prototype.getLabel);
+            inputBox = await InputBox.create();
+            assertEqualOptions(CAMEL_MISSIONS_EXPECTED, await convertArrayObjectsToText<QuickPickItem>(await inputBox.getQuickPicks()));
+            await inputBox.cancel();
         });
     });
 }
 
 
-function filterCatalogForRuntimes(catalog: any, runtimeIds:string[]) {
+function filterCatalogForRuntimes(catalog: any, runtimeIds: string[]) {
     let filteredCatalog = JSON.parse(JSON.stringify(catalog));
-    filteredCatalog.runtimes = catalog.runtimes.filter((runtime: any) => { return runtimeIds.indexOf(runtime.id) > -1;});
-    let filteredBoosters = catalog.boosters.filter((booster: any) => { return runtimeIds.indexOf(booster.runtime) > -1;});
+    filteredCatalog.runtimes = catalog.runtimes.filter((runtime: any) => { return runtimeIds.indexOf(runtime.id) > -1; });
+    let filteredBoosters = catalog.boosters.filter((booster: any) => { return runtimeIds.indexOf(booster.runtime) > -1; });
     filteredCatalog.boosters = filteredBoosters;
-    let filteredMissionIds = filteredBoosters.map((booster:any) => {return booster.mission;});
-    filteredCatalog.missions = catalog.missions.filter((mission:any) => {return filteredMissionIds.includes(mission.id);});
+    let filteredMissionIds = filteredBoosters.map((booster: any) => { return booster.mission; });
+    filteredCatalog.missions = catalog.missions.filter((mission: any) => { return filteredMissionIds.includes(mission.id); });
     return filteredCatalog;
 }
 
 function findRefsForMissions(mission: string, refCatalog: any) {
-    let missionsRefs = refCatalog.filter((ref: any) => { return mission.indexOf(ref.mission) > -1;});
+    let missionsRefs = refCatalog.filter((ref: any) => { return mission.indexOf(ref.mission) > -1; });
     return missionsRefs;
 }

--- a/src/ui-test/commandPaletteOptionsTest.ts
+++ b/src/ui-test/commandPaletteOptionsTest.ts
@@ -1,7 +1,6 @@
-import { InputBox, QuickOpenBox } from "vscode-extension-tester";
-import { getCommandPromptOptions, openCommandPrompt, typeCommandConfirm, verifyQuickPicks } from "./common/commonUtils";
-import { ProjectInitializer } from "./common/projectInitializerConstants";
-import { assertEqualOptions } from "./common/testUtils";
+import { InputBox, QuickOpenBox, QuickPickItem } from 'vscode-extension-tester';
+import { openCommandPrompt, typeCommandConfirm, verifyQuickPicks } from './common/commonUtils';
+import { ProjectInitializer } from './common/projectInitializerConstants';
 
 
 const GENERAL_PROJECT_EXPECTED = [
@@ -18,23 +17,27 @@ export function testCommandPaletteOffering() {
         let inputBox: InputBox | QuickOpenBox;
 
         it('Command palette should show proper options on the first level', async function () {
-            this.timeout(5000);
-            inputBox = await openCommandPrompt();
-            const options = await getCommandPromptOptions(">Project initializer");
-            assertEqualOptions(ProjectInitializer.FIRST_LEVEL_OPTIONS, options);
+            this.timeout(8000);
+            await inputBox.setText('>Project initializer');
+            await verifyQuickPicks(inputBox, ProjectInitializer.FIRST_LEVEL_OPTIONS, QuickPickItem.prototype.getLabel, 4500);
+            await inputBox.clear();
         });
 
         it('Options available after general Project Initializer project generation', async function () {
-            this.timeout(10000);
+            this.timeout(12000);
+            await typeCommandConfirm('>' + ProjectInitializer.PI_GENERAL.general, QuickPickItem.prototype.getLabel, 7500);
+            inputBox = await InputBox.create();
+            await verifyQuickPicks(inputBox, GENERAL_PROJECT_EXPECTED, QuickPickItem.prototype.getLabel, 5000);
+        });
+
+        before(async function () {
+            this.timeout(8000);
             inputBox = await openCommandPrompt();
-            await typeCommandConfirm('>' + ProjectInitializer.PI_GENERAL.general, true);
-            await verifyQuickPicks(inputBox, GENERAL_PROJECT_EXPECTED);
         });
 
         after(async function () {
-            if (inputBox && await inputBox.isDisplayed()) {
-                await inputBox.cancel();
-            }
+            // ignore cancel command if input is not visible
+            await inputBox?.cancel().catch(() => null);
         });
     });
 }


### PR DESCRIPTION
Changes:
* split big test cases into smaller test cases
* replaced " with ' in strings (only ui test code)
* format code + sort imports (only ui test code)
* reworked some utility functions to be more generic
* updated vscode-extension-tester

Signed-off-by: Marian Lorinc <mlorinc@redhat.com>